### PR TITLE
Makefile: Expand build command to create .flatpak file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
 # Output when building the Flatpak package.
 .flatpak-builder
 build-dir
+export/
+*.flatpak

--- a/Makefile
+++ b/Makefile
@@ -1,17 +1,19 @@
 build:
 	flatpak run --command=flatpak-builder org.flatpak.Builder --user --force-clean build-dir io.github.heathcliff26.go-minesweeper.yaml
+	flatpak build-export export build-dir
+	flatpak build-bundle export io.github.heathcliff26.go-minesweeper.flatpak io.github.heathcliff26.go-minesweeper
 
-install:
-	flatpak run --command=flatpak-builder org.flatpak.Builder --user --install --force-clean build-dir io.github.heathcliff26.go-minesweeper.yaml
+install: build
+	flatpak install --user -y io.github.heathcliff26.go-minesweeper.flatpak
 
 uninstall:
 	flatpak uninstall --user -y io.github.heathcliff26.go-minesweeper
 
-run:
+run: install
 	flatpak run --user io.github.heathcliff26.go-minesweeper
 
 lint:
 	flatpak run --command=flatpak-builder-lint org.flatpak.Builder manifest io.github.heathcliff26.go-minesweeper.yaml
 
 clean:
-	rm -rf .flatpak-builder build-dir
+	rm -rf .flatpak-builder build-dir export *.flatpak


### PR DESCRIPTION
Instead of just building the flatpak package, output the result as a .flatpak file.
This allows for easier installation and testing of the flatpak.